### PR TITLE
fix verify otp: increment if otp_status is not nil

### DIFF
--- a/lib/otp/active_record.rb
+++ b/lib/otp/active_record.rb
@@ -40,7 +40,7 @@ module OTP
       hotp = ROTP::HOTP.new(otp_secret, digits: otp_digits)
       transaction do
         otp_status = hotp.verify(otp.to_s, otp_counter)
-        increment!(:otp_counter)
+        increment!(:otp_counter) if otp_status
         otp_status
       end
     end


### PR DESCRIPTION
#### Fix Model#verify_otp

Сorrecting the situation when OTP is incorrect, and otp_counter has increased