### PR TITLE
Allow otp-jwt to work with none algorithm

### DIFF
--- a/lib/otp/jwt/token.rb
+++ b/lib/otp/jwt/token.rb
@@ -37,7 +37,16 @@ module OTP
       #
       # @return [Hash], JWT token payload
       def self.verify(token, opts = nil)
-        ::JWT.decode(token.to_s, self.jwt_signature_key, true, opts || {})
+        # When using the 'none' algorithm the JWT library requires
+        # password to be nil and verification to be disabled
+        # https://github.com/jwt/ruby-jwt/blame/master/README.md#L60-L61
+        verify = true
+        password = self.jwt_signature_key
+        if self.jwt_algorithm == 'none'
+          verify = false
+          password = nil
+        end
+        ::JWT.decode(token.to_s, password, verify, opts || {})
       end
 
       # Decodes a valid token into [Hash]

--- a/spec/otp/jwt/token_spec.rb
+++ b/spec/otp/jwt/token_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe OTP::JWT::Token, type: :model do
 
   describe '#sign' do
     it { expect(described_class.sign(payload)).to eq(token) }
+
+    context 'with the none algorithm' do
+      before do
+        OTP::JWT::Token.jwt_algorithm = 'none'
+      end
+
+      after do
+        OTP::JWT::Token.jwt_algorithm = 'HS256'
+      end
+
+      it { expect(described_class.sign(payload)).to eq(token) }
+    end
   end
 
   describe '#verify' do
@@ -48,6 +60,22 @@ RSpec.describe OTP::JWT::Token, type: :model do
 
       it do
         expect(described_class.decode(token)).to eq(nil)
+      end
+    end
+
+    context 'with the none algorithm' do
+      before do
+        OTP::JWT::Token.jwt_algorithm = 'none'
+      end
+
+      after do
+        OTP::JWT::Token.jwt_algorithm = 'HS256'
+      end
+
+      it do
+        expect(
+          described_class.decode(token) { |p| User.find(p['sub']) }
+        ).to eq(user)
       end
     end
   end


### PR DESCRIPTION
The JWT gem specifies to use the `none` algorithm that `nil` should be used for the `password` and `false` for verify. It would be nice to use the `none` algorithm in dev/test mode to allow easy examination of JWTs.

JWT Docs
https://github.com/jwt/ruby-jwt/blame/master/README.md#L60-L61