### PR TITLE
docs: Update `OTP::ActiveRecord#verify_otp` docs

### DIFF
--- a/lib/otp/active_record.rb
+++ b/lib/otp/active_record.rb
@@ -41,7 +41,7 @@ module OTP
       transaction do
         otp_status = hotp.verify(otp.to_s, otp_counter)
         increment!(:otp_counter)
-        otp_status
+        !otp_status.nil?
       end
     end
 

--- a/lib/otp/active_record.rb
+++ b/lib/otp/active_record.rb
@@ -32,7 +32,7 @@ module OTP
 
     # Verifies the OTP
     #
-    # @return true on success, false on failure
+    # @return otp_counter on success, nil on failure
     def verify_otp(otp)
       return nil if !valid? || !persisted? || otp_secret.blank?
 

--- a/lib/otp/active_record.rb
+++ b/lib/otp/active_record.rb
@@ -41,7 +41,7 @@ module OTP
       transaction do
         otp_status = hotp.verify(otp.to_s, otp_counter)
         increment!(:otp_counter)
-        !otp_status.nil?
+        otp_status
       end
     end
 


### PR DESCRIPTION
This PR updates the `OTP::ActiveRecord#verify_otp` method docs.

fixes #16 